### PR TITLE
Use leftover XP to repair other items

### DIFF
--- a/src/main/java/nge/lk/mods/mendingfix/MendingFix.java
+++ b/src/main/java/nge/lk/mods/mendingfix/MendingFix.java
@@ -79,12 +79,14 @@ public class MendingFix {
         player.onItemPickup(xp, 1);
 
         // -> The mending effect is applied and the xp value is recalculated.
-        while (!item.isEmpty() && xp.xpValue > 0) {
-            int realRepair = Math.min(xp.xpValue * DURABILITY_PER_XP, item.getItemDamage());
-            xp.xpValue -= realRepair / DURABILITY_PER_XP;
+        int repairPower = xp.xpValue * DURABILITY_PER_XP;
+        while (!item.isEmpty() && repairPower > 0) {
+            int realRepair = Math.min(repairPower, item.getItemDamage());
+            repairPower -= realRepair;
             item.setItemDamage(item.getItemDamage() - realRepair);
             item = getDamagedEnchantedItem(Enchantments.MENDING, player);
         }
+        xp.xpValue = repairPower / DURABILITY_PER_XP;
 
         // -> The XP are added to the player's experience.
         if (xp.xpValue > 0) {

--- a/src/main/java/nge/lk/mods/mendingfix/MendingFix.java
+++ b/src/main/java/nge/lk/mods/mendingfix/MendingFix.java
@@ -79,10 +79,11 @@ public class MendingFix {
         player.onItemPickup(xp, 1);
 
         // -> The mending effect is applied and the xp value is recalculated.
-        if (!item.isEmpty()) {
+        while (!item.isEmpty() && xp.xpValue > 0) {
             int realRepair = Math.min(xp.xpValue * DURABILITY_PER_XP, item.getItemDamage());
             xp.xpValue -= realRepair / DURABILITY_PER_XP;
             item.setItemDamage(item.getItemDamage() - realRepair);
+            item = getDamagedEnchantedItem(Enchantments.MENDING, player);
         }
 
         // -> The XP are added to the player's experience.


### PR DESCRIPTION
I love this mod! But, contrary to my intuition, I found a case where it still gives you experience points, even though there are items to repair. If the item chosen has only a tiny amount to repair, the remaining portion will be converted into player experience, even if you have other items to repair.

This is quite common when I hold a damaged pick in my off-hand and go out monster hunting to repair it. My sword and armor will constantly lose 1 durability each, and when they are selected for repair, most of the XP is "wasted" into experience. The amount of experience gained actually adds up quite a bit.

I fixed this by just adding a loop to repair items until either the XP is used up or there is nothing left to repair.